### PR TITLE
Chore/221112 dependency update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ com_crashlytics_export_strings.xml
 ehthumbs.db
 Thumbs.db
 .idea/inspectionProfiles
+deploymentTargetDropDown.xml

--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ This is a prototype of the app. As the backend isn't developed yet, this prototy
 This project has been reviewed and no longer in active development. 
 I would like to thank everyone at Sky for the positive feedback.
 
-Since I am now a Sky employee, I guess I have a need to thank Greg A. here for being my teammate in the past.
-This project concludes what I have learnt and improved after working closly with Greg for nearly 7 months.
+Since I have been awarded a role at Sky, 
+I believe I should thank Greg A. here for being my teammate in the past.
+This project concludes what I have learnt, reflected and improved,
+after working closly with Greg for nearly 7 months.
+
 Greg changed my life for the better. 
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
     defaultConfig {
         applicationId "uk.ryanwong.skycatnews"
         minSdk 26
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -130,9 +130,10 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.9.0'
 
-    def composeBom = platform('androidx.compose:compose-bom:2022.10.00')
+    def composeBom = platform('androidx.compose:compose-bom:2022.11.00')
     implementation composeBom
     androidTestImplementation composeBom
+
     implementation 'androidx.compose.material:material'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     debugImplementation 'androidx.compose.ui:ui-tooling'
@@ -148,10 +149,10 @@ dependencies {
     testImplementation "io.kotest:kotest-runner-junit5:$kotest_version"
     testImplementation "io.kotest:kotest-assertions-core:$kotest_version"
     testImplementation "io.kotest:kotest-property:$kotest_version"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-idling-resource:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-idling-resource:3.5.0'
     androidTestImplementation "io.kotest:kotest-assertions-core:$kotest_version"
 
     // Coil
@@ -190,7 +191,7 @@ dependencies {
     implementation 'com.google.accompanist:accompanist-swiperefresh:0.27.0'
 
     // debugImplementation because LeakCanary should only run in debug builds.
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'
 
     // Mockk
     testImplementation "io.mockk:mockk:$mockk_version"

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext {
         kotlin_version = '1.7.20'
-        kotest_version = '5.5.3'
-        hilt_version = '2.44'
+        kotest_version = '5.5.4'
+        hilt_version = '2.44.1'
         ktor_version = '2.1.3'
         room_version = '2.4.3'
         mockk_version = '1.13.2'


### PR DESCRIPTION
Summary of changes:

1. Update dependency & targetSdk versions - run unit tests and instrumented tests and passed
2. Improve README.md formatting
3. Update .gitignore

Note: Latest Kotlin version is currently 1.7.21 but kept 1.7.20 due to incompatibility with the Compose compiler.