### PR TITLE
[refactor] App: run AGP upgrade assistant to move namespace to build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,7 @@ plugins {
 }
 
 android {
+    namespace 'uk.ryanwong.skycatnews'
     compileSdk libs.versions.compileSdk.get().toInteger()
 
     signingConfigs {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="uk.ryanwong.skycatnews">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
A quick fix to remove the gradle build warning by running the AGP upgrade assistant - to move the namespace from AndroidManifest to build.gradle.

