### PR TITLE
[refactor] (#61) Provide view model and states to composables from Navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,7 +121,17 @@ android {
     }
     packagingOptions {
         resources {
-            excludes.add("/META-INF/*")
+            excludes.addAll(
+                listOf(
+                    "META-INF/proguard/*",
+                    "META-INF/*.kotlin_module",
+                    "META-INF/DEPENDENCIES",
+                    "META-INF/AL2.0",
+                    "META-INF/LGPL2.1",
+                    "META-INF/*.properties",
+                    "/*.properties",
+                ),
+            )
         }
     }
     buildFeatures {

--- a/app/src/main/java/uk/ryanwong/skycatnews/app/MainActivity.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/app/MainActivity.kt
@@ -10,20 +10,12 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.material.rememberScaffoldState
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.navigation.NavHostController
-import androidx.navigation.NavType
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
 import dagger.hilt.android.AndroidEntryPoint
 import uk.ryanwong.skycatnews.app.ui.component.SkyCatNewsAppBar
 import uk.ryanwong.skycatnews.app.ui.theme.SkyCatNewsTheme
-import uk.ryanwong.skycatnews.newslist.ui.screen.NewsListScreen
-import uk.ryanwong.skycatnews.storydetail.ui.screen.StoryDetailScreen
-import uk.ryanwong.skycatnews.weblink.ui.screen.WebLinkScreen
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.app.ui.SkyCatNewsApp
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -44,44 +36,6 @@ class MainActivity : ComponentActivity() {
                     )
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun SkyCatNewsApp(
-    modifier: Modifier = Modifier,
-    navController: NavHostController,
-) {
-
-    NavHost(navController = navController, startDestination = "newslist") {
-        composable(route = "newslist") {
-            NewsListScreen(
-                modifier = modifier,
-                onStoryItemClicked = { listId -> navController.navigate("newslist/story/$listId") },
-                onWebLinkItemClicked = { listId -> navController.navigate("newslist/weblink/$listId") },
-            )
-        }
-        composable(
-            route = "newslist/story/{list_id}",
-            arguments = listOf(
-                navArgument("list_id") {
-                    type = NavType.IntType
-                }
-            )
-        ) {
-            StoryDetailScreen(modifier = modifier)
-        }
-
-        composable(
-            route = "newslist/weblink/{list_id}",
-            arguments = listOf(
-                navArgument("list_id") {
-                    type = NavType.IntType
-                }
-            )
-        ) {
-            WebLinkScreen(modifier = modifier)
         }
     }
 }

--- a/app/src/main/java/uk/ryanwong/skycatnews/app/ui/SkyCatNewsApp.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/app/ui/SkyCatNewsApp.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023. Ryan Wong (hello@ryanwong.co.uk)
+ */
+
+package uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.app.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import uk.ryanwong.skycatnews.newslist.ui.screen.NewsListScreen
+import uk.ryanwong.skycatnews.storydetail.ui.screen.StoryDetailScreen
+import uk.ryanwong.skycatnews.weblink.ui.screen.WebLinkScreen
+
+@Composable
+fun SkyCatNewsApp(
+    modifier: Modifier = Modifier,
+    navController: NavHostController,
+) {
+
+    NavHost(navController = navController, startDestination = "newslist") {
+        composable(route = "newslist") {
+            NewsListScreen(
+                modifier = modifier,
+                onStoryItemClicked = { listId -> navController.navigate("newslist/story/$listId") },
+                onWebLinkItemClicked = { listId -> navController.navigate("newslist/weblink/$listId") },
+            )
+        }
+        composable(
+            route = "newslist/story/{list_id}",
+            arguments = listOf(
+                navArgument("list_id") {
+                    type = NavType.IntType
+                }
+            )
+        ) {
+            StoryDetailScreen(modifier = modifier)
+        }
+
+        composable(
+            route = "newslist/weblink/{list_id}",
+            arguments = listOf(
+                navArgument("list_id") {
+                    type = NavType.IntType
+                }
+            )
+        ) {
+            WebLinkScreen(modifier = modifier)
+        }
+    }
+}

--- a/app/src/main/java/uk/ryanwong/skycatnews/app/ui/SkyCatNewsApp.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/app/ui/SkyCatNewsApp.kt
@@ -5,7 +5,10 @@
 package uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.app.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -14,6 +17,7 @@ import androidx.navigation.navArgument
 import uk.ryanwong.skycatnews.newslist.ui.screen.NewsListScreen
 import uk.ryanwong.skycatnews.storydetail.ui.screen.StoryDetailScreen
 import uk.ryanwong.skycatnews.weblink.ui.screen.WebLinkScreen
+import uk.ryanwong.skycatnews.weblink.ui.viewmodel.WebLinkViewModel
 
 @Composable
 fun SkyCatNewsApp(
@@ -48,7 +52,14 @@ fun SkyCatNewsApp(
                 }
             )
         ) {
-            WebLinkScreen(modifier = modifier)
+            val webLinkViewModel: WebLinkViewModel = hiltViewModel()
+            val uiState by webLinkViewModel.uiState.collectAsStateWithLifecycle()
+
+            WebLinkScreen(
+                modifier = modifier,
+                uiState = uiState,
+                onErrorShown = { errorId -> (webLinkViewModel::errorShown)(errorId) }
+            )
         }
     }
 }

--- a/app/src/main/java/uk/ryanwong/skycatnews/app/ui/SkyCatNewsApp.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/app/ui/SkyCatNewsApp.kt
@@ -15,8 +15,10 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import uk.ryanwong.skycatnews.newslist.ui.screen.NewsListScreen
+import uk.ryanwong.skycatnews.newslist.ui.viewmodel.NewsListViewModel
 import uk.ryanwong.skycatnews.storydetail.ui.screen.StoryDetailScreen
 import uk.ryanwong.skycatnews.storydetail.ui.viewmodel.StoryDetailViewModel
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.newslist.ui.NewsListUIEvent
 import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.storydetail.ui.StoryDetailUIEvent
 import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.weblink.ui.WebLinkUIEvent
 import uk.ryanwong.skycatnews.weblink.ui.screen.WebLinkScreen
@@ -29,10 +31,18 @@ fun SkyCatNewsApp(
 ) {
     NavHost(navController = navController, startDestination = "newslist") {
         composable(route = "newslist") {
+            val newsListViewModel: NewsListViewModel = hiltViewModel()
+            val uiState by newsListViewModel.uiState.collectAsStateWithLifecycle()
+
             NewsListScreen(
                 modifier = modifier,
-                onStoryItemClicked = { listId -> navController.navigate("newslist/story/$listId") },
-                onWebLinkItemClicked = { listId -> navController.navigate("newslist/weblink/$listId") },
+                uiState = uiState,
+                uiEvent = NewsListUIEvent(
+                    onRefresh = { newsListViewModel.refreshNewsList() },
+                    onStoryItemClicked = { listId -> navController.navigate("newslist/story/$listId") },
+                    onWebLinkItemClicked = { listId -> navController.navigate("newslist/weblink/$listId") },
+                    onErrorShown = { errorId -> (newsListViewModel::errorShown)(errorId) }
+                )
             )
         }
         composable(
@@ -51,7 +61,7 @@ fun SkyCatNewsApp(
                 uiState = uiState,
                 uiEvent = StoryDetailUIEvent(
                     onRefresh = { storyDetailViewModel.refreshStory() },
-                    onErrorShown = { errorId -> storyDetailViewModel.errorShown(errorId = errorId) }
+                    onErrorShown = { errorId -> (storyDetailViewModel::errorShown)(errorId) }
                 )
             )
         }

--- a/app/src/main/java/uk/ryanwong/skycatnews/app/ui/SkyCatNewsApp.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/app/ui/SkyCatNewsApp.kt
@@ -16,6 +16,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import uk.ryanwong.skycatnews.newslist.ui.screen.NewsListScreen
 import uk.ryanwong.skycatnews.storydetail.ui.screen.StoryDetailScreen
+import uk.ryanwong.skycatnews.storydetail.ui.viewmodel.StoryDetailViewModel
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.storydetail.ui.StoryDetailUIEvent
 import uk.ryanwong.skycatnews.weblink.ui.screen.WebLinkScreen
 import uk.ryanwong.skycatnews.weblink.ui.viewmodel.WebLinkViewModel
 
@@ -24,7 +26,6 @@ fun SkyCatNewsApp(
     modifier: Modifier = Modifier,
     navController: NavHostController,
 ) {
-
     NavHost(navController = navController, startDestination = "newslist") {
         composable(route = "newslist") {
             NewsListScreen(
@@ -41,7 +42,17 @@ fun SkyCatNewsApp(
                 }
             )
         ) {
-            StoryDetailScreen(modifier = modifier)
+            val storyDetailViewModel: StoryDetailViewModel = hiltViewModel()
+            val uiState by storyDetailViewModel.uiState.collectAsStateWithLifecycle()
+
+            StoryDetailScreen(
+                modifier = modifier,
+                uiState = uiState,
+                uiEvent = StoryDetailUIEvent(
+                    onRefresh = { storyDetailViewModel.refreshStory() },
+                    onErrorShown = { errorId -> storyDetailViewModel.errorShown(errorId = errorId) }
+                )
+            )
         }
 
         composable(

--- a/app/src/main/java/uk/ryanwong/skycatnews/app/ui/SkyCatNewsApp.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/app/ui/SkyCatNewsApp.kt
@@ -18,6 +18,7 @@ import uk.ryanwong.skycatnews.newslist.ui.screen.NewsListScreen
 import uk.ryanwong.skycatnews.storydetail.ui.screen.StoryDetailScreen
 import uk.ryanwong.skycatnews.storydetail.ui.viewmodel.StoryDetailViewModel
 import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.storydetail.ui.StoryDetailUIEvent
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.weblink.ui.WebLinkUIEvent
 import uk.ryanwong.skycatnews.weblink.ui.screen.WebLinkScreen
 import uk.ryanwong.skycatnews.weblink.ui.viewmodel.WebLinkViewModel
 
@@ -69,7 +70,9 @@ fun SkyCatNewsApp(
             WebLinkScreen(
                 modifier = modifier,
                 uiState = uiState,
-                onErrorShown = { errorId -> (webLinkViewModel::errorShown)(errorId) }
+                uiEvent = WebLinkUIEvent(
+                    onErrorShown = { errorId -> (webLinkViewModel::errorShown)(errorId) }
+                )
             )
         }
     }

--- a/app/src/main/java/uk/ryanwong/skycatnews/newslist/ui/NewsListUIEvent.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/newslist/ui/NewsListUIEvent.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2023. Ryan Wong (hello@ryanwong.co.uk)
+ */
+
+package uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.newslist.ui
+
+data class NewsListUIEvent(
+    val onStoryItemClicked: (id: Int) -> Unit,
+    val onWebLinkItemClicked: (id: Int) -> Unit,
+    val onRefresh: () -> Unit,
+    val onErrorShown: (errorId: Long) -> Unit,
+)

--- a/app/src/main/java/uk/ryanwong/skycatnews/newslist/ui/NewsListUIState.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/newslist/ui/NewsListUIState.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2022. Ryan Wong (hello@ryanwong.co.uk)
  */
 
-package uk.ryanwong.skycatnews.newslist.ui.viewmodel
+package uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.newslist.ui
 
 import uk.ryanwong.skycatnews.app.util.ErrorMessage
 import uk.ryanwong.skycatnews.newslist.domain.model.NewsItem

--- a/app/src/main/java/uk/ryanwong/skycatnews/newslist/ui/screen/NewsListScreen.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/newslist/ui/screen/NewsListScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,8 +30,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import uk.ryanwong.skycatnews.R
 import uk.ryanwong.skycatnews.app.ui.component.NoDataScreen
 import uk.ryanwong.skycatnews.app.ui.theme.SkyCatNewsTheme
@@ -42,26 +39,25 @@ import uk.ryanwong.skycatnews.newslist.ui.screen.component.LargeWebLinkHeadline
 import uk.ryanwong.skycatnews.newslist.ui.screen.component.RegularStoryHeadline
 import uk.ryanwong.skycatnews.newslist.ui.screen.component.RegularWebLinkHeadline
 import uk.ryanwong.skycatnews.newslist.ui.screen.previewparameter.NewsListProvider
-import uk.ryanwong.skycatnews.newslist.ui.viewmodel.NewsListViewModel
 import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.app.ui.theme.getDimension
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.newslist.ui.NewsListUIEvent
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.newslist.ui.NewsListUIState
 
 @Composable
 fun NewsListScreen(
     modifier: Modifier = Modifier,
-    newsListViewModel: NewsListViewModel = hiltViewModel(),
-    onStoryItemClicked: (id: Int) -> Unit,
-    onWebLinkItemClicked: (id: Int) -> Unit,
+    uiState: NewsListUIState,
+    uiEvent: NewsListUIEvent,
 ) {
-    val uiState by newsListViewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
 
     Box(modifier = modifier.fillMaxSize()) {
         NewsListScreenLayout(
             newsList = uiState.newsList,
             isLoading = uiState.isLoading,
-            onRefresh = { newsListViewModel.refreshNewsList() },
-            onStoryItemClicked = onStoryItemClicked,
-            onWebLinkItemClicked = onWebLinkItemClicked,
+            onRefresh = uiEvent.onRefresh,
+            onStoryItemClicked = uiEvent.onStoryItemClicked,
+            onWebLinkItemClicked = uiEvent.onWebLinkItemClicked,
         )
 
         SnackbarHost(
@@ -80,7 +76,7 @@ fun NewsListScreen(
                 message = errorMessageText,
                 actionLabel = actionLabel
             )
-            newsListViewModel.errorShown(errorId = errorMessage.id)
+            uiEvent.onErrorShown(errorMessage.id)
         }
     }
 }

--- a/app/src/main/java/uk/ryanwong/skycatnews/newslist/ui/screen/NewsListScreen.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/newslist/ui/screen/NewsListScreen.kt
@@ -6,42 +6,25 @@ package uk.ryanwong.skycatnews.newslist.ui.screen
 
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.SnackbarHost
 import androidx.compose.material.SnackbarHostState
-import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.pullRefresh
-import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import uk.ryanwong.skycatnews.R
-import uk.ryanwong.skycatnews.app.ui.component.NoDataScreen
 import uk.ryanwong.skycatnews.app.ui.theme.SkyCatNewsTheme
 import uk.ryanwong.skycatnews.newslist.domain.model.NewsItem
-import uk.ryanwong.skycatnews.newslist.ui.screen.component.LargeStoryHeadline
-import uk.ryanwong.skycatnews.newslist.ui.screen.component.LargeWebLinkHeadline
-import uk.ryanwong.skycatnews.newslist.ui.screen.component.RegularStoryHeadline
-import uk.ryanwong.skycatnews.newslist.ui.screen.component.RegularWebLinkHeadline
 import uk.ryanwong.skycatnews.newslist.ui.screen.previewparameter.NewsListProvider
-import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.app.ui.theme.getDimension
 import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.newslist.ui.NewsListUIEvent
 import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.newslist.ui.NewsListUIState
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.newslist.ui.screen.component.NewsListScreenLayout
 
 @Composable
 fun NewsListScreen(
@@ -81,109 +64,12 @@ fun NewsListScreen(
     }
 }
 
-@OptIn(ExperimentalMaterialApi::class)
-@Composable
-fun NewsListScreenLayout(
-    newsList: List<NewsItem>,
-    isLoading: Boolean,
-    onRefresh: () -> Unit,
-    onStoryItemClicked: (id: Int) -> Unit,
-    onWebLinkItemClicked: (id: Int) -> Unit,
-) {
-    val dimension = LocalConfiguration.current.getDimension()
-    val contentDescriptionNewsList = stringResource(R.string.content_description_news_list)
-    val pullRefreshState = rememberPullRefreshState(refreshing = isLoading, onRefresh = onRefresh)
-
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(color = MaterialTheme.colors.background)
-            .pullRefresh(pullRefreshState),
-    ) {
-        LazyColumn(
-            contentPadding = PaddingValues(vertical = dimension.grid_2),
-            modifier = Modifier
-                .fillMaxSize()
-                .semantics { contentDescription = contentDescriptionNewsList }
-        ) {
-            if (newsList.isEmpty()) {
-                if (!isLoading) {
-                    item {
-                        NoDataScreen(modifier = Modifier.fillParentMaxHeight())
-                    }
-                }
-                return@LazyColumn
-            }
-
-            item {
-                val firstItem = newsList.first()
-                when (firstItem) {
-                    is NewsItem.Story -> {
-                        LargeStoryHeadline(
-                            story = firstItem,
-                            onItemClicked = { onStoryItemClicked(firstItem.newsId) },
-                        )
-                    }
-
-                    is NewsItem.WebLink -> {
-                        LargeWebLinkHeadline(
-                            webLink = firstItem,
-                            onItemClicked = { onWebLinkItemClicked(firstItem.newsId) },
-                        )
-                    }
-                }
-            }
-
-            val regularItemsList = newsList.subList(1, newsList.size)
-            itemsIndexed(regularItemsList) { _, newsItem ->
-                when (newsItem) {
-                    is NewsItem.Story -> {
-                        RegularStoryHeadline(
-                            story = newsItem,
-                            onItemClicked = { onStoryItemClicked(newsItem.newsId) },
-                        )
-                    }
-
-                    is NewsItem.WebLink -> {
-                        RegularWebLinkHeadline(
-                            webLink = newsItem,
-                            onItemClicked = { onWebLinkItemClicked(newsItem.newsId) },
-                        )
-                    }
-                }
-            }
-        }
-
-        PullRefreshIndicator(
-            refreshing = isLoading,
-            state = pullRefreshState,
-            modifier = Modifier.align(Alignment.TopCenter)
-        )
-    }
-}
-
 @Preview(
     name = "News List Screen",
     group = "Light",
     showBackground = true,
     uiMode = UI_MODE_NIGHT_NO,
 )
-@Composable
-private fun NewsListScreenPreviewLight(
-    @PreviewParameter(NewsListProvider::class)
-    newsList: List<NewsItem>,
-) {
-    SkyCatNewsTheme {
-        NewsListScreenLayout(
-            newsList = newsList,
-            isLoading = false,
-            onRefresh = { },
-            onStoryItemClicked = {},
-            onWebLinkItemClicked = {},
-        )
-    }
-}
-
 @Preview(
     name = "News List Screen",
     group = "Dark",
@@ -191,17 +77,21 @@ private fun NewsListScreenPreviewLight(
     uiMode = UI_MODE_NIGHT_YES,
 )
 @Composable
-private fun NewsListScreenPreviewDark(
+private fun NewsListScreenPreview(
     @PreviewParameter(NewsListProvider::class)
     newsList: List<NewsItem>,
 ) {
     SkyCatNewsTheme {
-        NewsListScreenLayout(
-            newsList = newsList,
-            isLoading = false,
-            onRefresh = { },
-            onStoryItemClicked = {},
-            onWebLinkItemClicked = {},
+        NewsListScreen(
+            uiState = NewsListUIState(
+                newsList = newsList,
+            ),
+            uiEvent = NewsListUIEvent(
+                onStoryItemClicked = {},
+                onWebLinkItemClicked = {},
+                onRefresh = {},
+                onErrorShown = {},
+            ),
         )
     }
 }
@@ -212,19 +102,6 @@ private fun NewsListScreenPreviewDark(
     showBackground = true,
     uiMode = UI_MODE_NIGHT_NO,
 )
-@Composable
-private fun NewsListScreenNoDataPreviewLight() {
-    SkyCatNewsTheme {
-        NewsListScreenLayout(
-            newsList = emptyList(),
-            isLoading = false,
-            onRefresh = { },
-            onStoryItemClicked = {},
-            onWebLinkItemClicked = {},
-        )
-    }
-}
-
 @Preview(
     name = "News List Screen No Data",
     group = "Dark",
@@ -232,14 +109,18 @@ private fun NewsListScreenNoDataPreviewLight() {
     uiMode = UI_MODE_NIGHT_YES,
 )
 @Composable
-private fun NewsListScreenNoDataPreviewDark() {
+private fun NewsListScreenNoDataPreview() {
     SkyCatNewsTheme {
-        NewsListScreenLayout(
-            newsList = emptyList(),
-            isLoading = false,
-            onRefresh = { },
-            onStoryItemClicked = {},
-            onWebLinkItemClicked = {},
+        NewsListScreen(
+            uiState = NewsListUIState(
+                newsList = emptyList(),
+            ),
+            uiEvent = NewsListUIEvent(
+                onStoryItemClicked = {},
+                onWebLinkItemClicked = {},
+                onRefresh = {},
+                onErrorShown = {},
+            ),
         )
     }
 }

--- a/app/src/main/java/uk/ryanwong/skycatnews/newslist/ui/screen/component/NewsListScreenLayout.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/newslist/ui/screen/component/NewsListScreenLayout.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023. Ryan Wong (hello@ryanwong.co.uk)
+ */
+
+package uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.newslist.ui.screen.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import uk.ryanwong.skycatnews.R
+import uk.ryanwong.skycatnews.app.ui.component.NoDataScreen
+import uk.ryanwong.skycatnews.newslist.domain.model.NewsItem
+import uk.ryanwong.skycatnews.newslist.ui.screen.component.LargeStoryHeadline
+import uk.ryanwong.skycatnews.newslist.ui.screen.component.LargeWebLinkHeadline
+import uk.ryanwong.skycatnews.newslist.ui.screen.component.RegularStoryHeadline
+import uk.ryanwong.skycatnews.newslist.ui.screen.component.RegularWebLinkHeadline
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.app.ui.theme.getDimension
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun NewsListScreenLayout(
+    newsList: List<NewsItem>,
+    isLoading: Boolean,
+    onRefresh: () -> Unit,
+    onStoryItemClicked: (id: Int) -> Unit,
+    onWebLinkItemClicked: (id: Int) -> Unit,
+) {
+    val dimension = LocalConfiguration.current.getDimension()
+    val contentDescriptionNewsList = stringResource(R.string.content_description_news_list)
+    val pullRefreshState = rememberPullRefreshState(refreshing = isLoading, onRefresh = onRefresh)
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = MaterialTheme.colors.background)
+            .pullRefresh(pullRefreshState),
+    ) {
+        LazyColumn(
+            contentPadding = PaddingValues(vertical = dimension.grid_2),
+            modifier = Modifier
+                .fillMaxSize()
+                .semantics { contentDescription = contentDescriptionNewsList }
+        ) {
+            if (newsList.isEmpty()) {
+                if (!isLoading) {
+                    item {
+                        NoDataScreen(modifier = Modifier.fillParentMaxHeight())
+                    }
+                }
+                return@LazyColumn
+            }
+
+            item {
+                val firstItem = newsList.first()
+                when (firstItem) {
+                    is NewsItem.Story -> {
+                        LargeStoryHeadline(
+                            story = firstItem,
+                            onItemClicked = { onStoryItemClicked(firstItem.newsId) },
+                        )
+                    }
+
+                    is NewsItem.WebLink -> {
+                        LargeWebLinkHeadline(
+                            webLink = firstItem,
+                            onItemClicked = { onWebLinkItemClicked(firstItem.newsId) },
+                        )
+                    }
+                }
+            }
+
+            val regularItemsList = newsList.subList(1, newsList.size)
+            itemsIndexed(regularItemsList) { _, newsItem ->
+                when (newsItem) {
+                    is NewsItem.Story -> {
+                        RegularStoryHeadline(
+                            story = newsItem,
+                            onItemClicked = { onStoryItemClicked(newsItem.newsId) },
+                        )
+                    }
+
+                    is NewsItem.WebLink -> {
+                        RegularWebLinkHeadline(
+                            webLink = newsItem,
+                            onItemClicked = { onWebLinkItemClicked(newsItem.newsId) },
+                        )
+                    }
+                }
+            }
+        }
+
+        PullRefreshIndicator(
+            refreshing = isLoading,
+            state = pullRefreshState,
+            modifier = Modifier.align(Alignment.TopCenter)
+        )
+    }
+}

--- a/app/src/main/java/uk/ryanwong/skycatnews/newslist/ui/viewmodel/NewsListViewModel.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/newslist/ui/viewmodel/NewsListViewModel.kt
@@ -18,6 +18,7 @@ import uk.ryanwong.skycatnews.R
 import uk.ryanwong.skycatnews.app.di.DispatcherModule
 import uk.ryanwong.skycatnews.app.util.ErrorMessage
 import uk.ryanwong.skycatnews.newslist.data.repository.NewsListRepository
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.newslist.ui.NewsListUIState
 
 @HiltViewModel
 class NewsListViewModel @Inject constructor(

--- a/app/src/main/java/uk/ryanwong/skycatnews/storydetail/ui/StoryDetailUIEvent.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/storydetail/ui/StoryDetailUIEvent.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2023. Ryan Wong (hello@ryanwong.co.uk)
+ */
+
+package uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.storydetail.ui
+
+data class StoryDetailUIEvent(
+    val onRefresh: () -> Unit,
+    val onErrorShown: (errorId: Long) -> Unit,
+)

--- a/app/src/main/java/uk/ryanwong/skycatnews/storydetail/ui/StoryDetailUIState.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/storydetail/ui/StoryDetailUIState.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2022. Ryan Wong (hello@ryanwong.co.uk)
  */
 
-package uk.ryanwong.skycatnews.storydetail.ui.viewmodel
+package uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.storydetail.ui
 
 import uk.ryanwong.skycatnews.app.util.ErrorMessage
 import uk.ryanwong.skycatnews.storydetail.domain.model.Story

--- a/app/src/main/java/uk/ryanwong/skycatnews/storydetail/ui/screen/StoryDetailScreen.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/storydetail/ui/screen/StoryDetailScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,8 +42,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import uk.ryanwong.skycatnews.R
@@ -56,22 +53,24 @@ import uk.ryanwong.skycatnews.app.ui.theme.SkyCatNewsTheme
 import uk.ryanwong.skycatnews.storydetail.domain.model.Content
 import uk.ryanwong.skycatnews.storydetail.domain.model.Story
 import uk.ryanwong.skycatnews.storydetail.ui.previewparameter.StoryProvider
-import uk.ryanwong.skycatnews.storydetail.ui.viewmodel.StoryDetailViewModel
 import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.app.ui.theme.getDimension
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.storydetail.ui.StoryDetailUIEvent
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.storydetail.ui.StoryDetailUIState
 
 @Composable
 fun StoryDetailScreen(
     modifier: Modifier = Modifier,
-    storyDetailViewModel: StoryDetailViewModel = hiltViewModel(),
+    uiState: StoryDetailUIState,
+    uiEvent: StoryDetailUIEvent,
 ) {
-    val uiState by storyDetailViewModel.uiState.collectAsStateWithLifecycle()
+
     val snackbarHostState = remember { SnackbarHostState() }
 
     Box(modifier = modifier.fillMaxSize()) {
         StoryDetailScreenLayout(
             story = uiState.story,
             isLoading = uiState.isLoading,
-            onRefresh = { storyDetailViewModel.refreshStory() }
+            onRefresh = uiEvent.onRefresh,
         )
 
         SnackbarHost(
@@ -90,7 +89,7 @@ fun StoryDetailScreen(
                 message = errorMessageText,
                 actionLabel = actionLabel
             )
-            storyDetailViewModel.errorShown(errorId = errorMessage.id)
+            uiEvent.onErrorShown(errorMessage.id)
         }
     }
 }

--- a/app/src/main/java/uk/ryanwong/skycatnews/storydetail/ui/screen/StoryDetailScreen.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/storydetail/ui/screen/StoryDetailScreen.kt
@@ -250,53 +250,28 @@ private fun HeroImageSection(
 
 @Preview(
     group = "story loaded",
+    name = "small screen - light",
     showSystemUi = true,
     showBackground = true,
     uiMode = UI_MODE_NIGHT_NO,
     device = androidx.compose.ui.tooling.preview.Devices.NEXUS_5
 )
-@Composable
-private fun StoryDetailScreenLayoutPreviewLightSmallScreen(
-    @PreviewParameter(StoryProvider::class)
-    story: Story,
-) {
-    SkyCatNewsTheme {
-        StoryDetailScreenLayout(
-            isLoading = false,
-            story = story,
-            onRefresh = {},
-        )
-    }
-}
-
 @Preview(
     group = "story loaded",
+    name = "regular screen - light",
     showSystemUi = true,
     showBackground = true,
     uiMode = UI_MODE_NIGHT_NO,
 )
-@Composable
-private fun StoryDetailScreenLayoutPreviewLight(
-    @PreviewParameter(StoryProvider::class)
-    story: Story,
-) {
-    SkyCatNewsTheme {
-        StoryDetailScreenLayout(
-            isLoading = false,
-            story = story,
-            onRefresh = {},
-        )
-    }
-}
-
 @Preview(
     group = "story loaded",
+    name = "regular screen - dark",
     showSystemUi = true,
     showBackground = true,
     uiMode = UI_MODE_NIGHT_YES,
 )
 @Composable
-private fun StoryDetailScreenLayoutPreviewDark(
+private fun StoryDetailScreenLayoutPreview(
     @PreviewParameter(StoryProvider::class)
     story: Story,
 ) {
@@ -311,29 +286,20 @@ private fun StoryDetailScreenLayoutPreviewDark(
 
 @Preview(
     group = "no data",
+    name = "light",
     showSystemUi = true,
     showBackground = true,
     uiMode = UI_MODE_NIGHT_NO,
 )
-@Composable
-private fun StoryDetailScreenLayoutNoDataPreviewLight() {
-    SkyCatNewsTheme {
-        StoryDetailScreenLayout(
-            isLoading = false,
-            story = null,
-            onRefresh = {},
-        )
-    }
-}
-
 @Preview(
     group = "no data",
+    name = "dark",
     showSystemUi = true,
     showBackground = true,
     uiMode = UI_MODE_NIGHT_YES,
 )
 @Composable
-private fun StoryDetailScreenLayoutNoDataPreviewDark() {
+private fun StoryDetailScreenLayoutNoDataPreview() {
     SkyCatNewsTheme {
         StoryDetailScreenLayout(
             isLoading = false,

--- a/app/src/main/java/uk/ryanwong/skycatnews/storydetail/ui/viewmodel/StoryDetailViewModel.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/storydetail/ui/viewmodel/StoryDetailViewModel.kt
@@ -19,6 +19,7 @@ import uk.ryanwong.skycatnews.R
 import uk.ryanwong.skycatnews.app.di.DispatcherModule
 import uk.ryanwong.skycatnews.app.util.ErrorMessage
 import uk.ryanwong.skycatnews.storydetail.data.repository.StoryDetailRepository
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.storydetail.ui.StoryDetailUIState
 
 @HiltViewModel
 class StoryDetailViewModel @Inject constructor(

--- a/app/src/main/java/uk/ryanwong/skycatnews/weblink/ui/WebLinkUIEvent.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/weblink/ui/WebLinkUIEvent.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2023. Ryan Wong (hello@ryanwong.co.uk)
+ */
+
+package uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.weblink.ui
+
+data class WebLinkUIEvent(
+    val onErrorShown: (errorId: Long) -> Unit,
+)

--- a/app/src/main/java/uk/ryanwong/skycatnews/weblink/ui/WebLinkUIState.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/weblink/ui/WebLinkUIState.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2022. Ryan Wong (hello@ryanwong.co.uk)
  */
 
-package uk.ryanwong.skycatnews.weblink.ui.viewmodel
+package uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.weblink.ui
 
 import uk.ryanwong.skycatnews.app.util.ErrorMessage
 

--- a/app/src/main/java/uk/ryanwong/skycatnews/weblink/ui/screen/WebLinkScreen.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/weblink/ui/screen/WebLinkScreen.kt
@@ -21,13 +21,14 @@ import androidx.compose.ui.semantics.semantics
 import com.google.accompanist.web.WebView
 import com.google.accompanist.web.rememberWebViewState
 import uk.ryanwong.skycatnews.R
-import uk.ryanwong.skycatnews.weblink.ui.viewmodel.WebLinkUIState
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.weblink.ui.WebLinkUIEvent
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.weblink.ui.WebLinkUIState
 
 @Composable
 fun WebLinkScreen(
     modifier: Modifier = Modifier,
     uiState: WebLinkUIState,
-    onErrorShown: (errorId: Long) -> Unit,
+    uiEvent: WebLinkUIEvent,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -59,7 +60,7 @@ fun WebLinkScreen(
                 message = errorMessageText,
                 actionLabel = actionLabel
             )
-            onErrorShown(errorMessage.id)
+            uiEvent.onErrorShown(errorMessage.id)
         }
     }
 }

--- a/app/src/main/java/uk/ryanwong/skycatnews/weblink/ui/screen/WebLinkScreen.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/weblink/ui/screen/WebLinkScreen.kt
@@ -12,26 +12,23 @@ import androidx.compose.material.SnackbarHost
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.web.WebView
 import com.google.accompanist.web.rememberWebViewState
 import uk.ryanwong.skycatnews.R
-import uk.ryanwong.skycatnews.weblink.ui.viewmodel.WebLinkViewModel
+import uk.ryanwong.skycatnews.weblink.ui.viewmodel.WebLinkUIState
 
 @Composable
 fun WebLinkScreen(
     modifier: Modifier = Modifier,
-    webLinkViewModel: WebLinkViewModel = hiltViewModel(),
+    uiState: WebLinkUIState,
+    onErrorShown: (errorId: Long) -> Unit,
 ) {
-    val uiState by webLinkViewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
 
     Box(modifier = modifier.fillMaxSize()) {
@@ -62,7 +59,7 @@ fun WebLinkScreen(
                 message = errorMessageText,
                 actionLabel = actionLabel
             )
-            webLinkViewModel.errorShown(errorId = errorMessage.id)
+            onErrorShown(errorMessage.id)
         }
     }
 }

--- a/app/src/main/java/uk/ryanwong/skycatnews/weblink/ui/viewmodel/WebLinkViewModel.kt
+++ b/app/src/main/java/uk/ryanwong/skycatnews/weblink/ui/viewmodel/WebLinkViewModel.kt
@@ -20,6 +20,7 @@ import uk.ryanwong.skycatnews.app.di.DispatcherModule
 import uk.ryanwong.skycatnews.app.util.ErrorMessage
 import uk.ryanwong.skycatnews.newslist.data.repository.NewsListRepository
 import uk.ryanwong.skycatnews.newslist.domain.model.NewsItem
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.weblink.ui.WebLinkUIState
 
 @HiltViewModel
 class WebLinkViewModel @Inject constructor(

--- a/app/src/test/java/uk/ryanwong/skycatnews/newslist/ui/viewmodel/NewsListViewModelTest.kt
+++ b/app/src/test/java/uk/ryanwong/skycatnews/newslist/ui/viewmodel/NewsListViewModelTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import uk.ryanwong.skycatnews.R
 import uk.ryanwong.skycatnews.newslist.data.repository.MockNewsListRepository
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.newslist.ui.NewsListUIState
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class NewsListViewModelTest : FreeSpec() {

--- a/app/src/test/java/uk/ryanwong/skycatnews/newslist/ui/viewmodel/WebLinkViewModelTest.kt
+++ b/app/src/test/java/uk/ryanwong/skycatnews/newslist/ui/viewmodel/WebLinkViewModelTest.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import uk.ryanwong.skycatnews.R
 import uk.ryanwong.skycatnews.newslist.data.repository.MockNewsListRepository
-import uk.ryanwong.skycatnews.weblink.ui.viewmodel.WebLinkUIState
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.weblink.ui.WebLinkUIState
 import uk.ryanwong.skycatnews.weblink.ui.viewmodel.WebLinkViewModel
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/java/uk/ryanwong/skycatnews/storydetail/ui/viewmodel/StoryDetailViewModelTest.kt
+++ b/app/src/test/java/uk/ryanwong/skycatnews/storydetail/ui/viewmodel/StoryDetailViewModelTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.test.runTest
 import uk.ryanwong.skycatnews.R
 import uk.ryanwong.skycatnews.app.exception.StoryNotFoundException
 import uk.ryanwong.skycatnews.storydetail.data.repository.MockStoryDetailRepository
+import uk.ryanwong.skycatnews.uk.ryanwong.skycatnews.storydetail.ui.StoryDetailUIState
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class StoryDetailViewModelTest : FreeSpec() {


### PR DESCRIPTION
This PR covers:
1. Move the hiltViewModel() calls from composables to the upper Navigation Graph, so all screens now no longer coupled to ViewModel and are previewable.
2. Create UIEvent to propagate down the list of higher order functions so simplify the composable function signatures.
3. Combine several preview functions to avoid repetitions.


This is the first PR raised directly from Android Studio.