### PR TITLE
[chore] Gradle: remove signing for debug builds, use environment variables if local keystore file is unavailable

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,7 +23,7 @@ android {
     signingConfigs {
         create("release") {
             val isRunningOnBitrise = System.getenv("BITRISE") == "true"
-            val keystorePropertiesFile = file("../../../keystore.properties")
+            val keystorePropertiesFile = file("../../keystore.properties")
 
             if (isRunningOnBitrise || !keystorePropertiesFile.exists()) {
                 keyAlias = System.getenv("BITRISEIO_ANDROID_KEYSTORE_ALIAS")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,15 +23,16 @@ android {
     signingConfigs {
         create("release") {
             val isRunningOnBitrise = System.getenv("BITRISE") == "true"
-            if (isRunningOnBitrise) {
+            val keystorePropertiesFile = file("../../../keystore.properties")
+
+            if (isRunningOnBitrise || !keystorePropertiesFile.exists()) {
                 keyAlias = System.getenv("BITRISEIO_ANDROID_KEYSTORE_ALIAS")
                 keyPassword = System.getenv("BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD")
                 storeFile = file(System.getenv("HOME") + "/keystores/release.jks")
                 storePassword = System.getenv("BITRISEIO_ANDROID_KEYSTORE_PASSWORD")
             } else {
                 val properties = Properties()
-                val localProperties = File("../../keystore.properties")
-                InputStreamReader(FileInputStream(localProperties), Charsets.UTF_8).use { reader ->
+                InputStreamReader(FileInputStream(keystorePropertiesFile), Charsets.UTF_8).use { reader ->
                     properties.load(reader)
                 }
 
@@ -67,7 +68,6 @@ android {
             isMinifyEnabled = false
             isDebuggable = true
 
-            signingConfig = signingConfigs.getByName("release")
             applicationVariants.all {
                 val variant = this
                 variant.outputs


### PR DESCRIPTION
Thanks MSMG for the feedback. 

This is a workaround to make the project works (at least for debug) without needing to set up a keystore. Will further refine when the Github actions is revisited.

If the keystore.properties does not exist, it will fallback to the environment variables CI/CD route, which will at least surpress the Gradle sync error.

Debug build won't sign anymore, so it won't trigger any error even the keystore details are not there.